### PR TITLE
Made encoding and autojunk explicit as kwargs on init

### DIFF
--- a/htmldiffer/diff.py
+++ b/htmldiffer/diff.py
@@ -24,7 +24,7 @@ class HTMLDiffer:
         else:
             self.html_b = html_b
 
-        self.deleted_diff, self.inserted_diff, self.combined_diff = self.diff(autojunk=autojunk)
+        self.deleted_diff, self.inserted_diff, self.combined_diff, self.s = self.diff(autojunk=autojunk)
 
     def diff(self, autojunk=False):
         """Takes in strings a and b and returns HTML diffs: deletes, inserts, and combined."""
@@ -70,8 +70,11 @@ class HTMLDiffer:
         # using BeautifulSoup to fix any potentially broken tags
         # see https://github.com/anastasia/htmldiffer/issues/28
         combined_diff = str(BeautifulSoup(''.join(out[2]), 'html.parser'))
-
-        return deleted_diff, inserted_diff, combined_diff
+        
+        return deleted_diff, inserted_diff, combined_diff, s
+    
+    def ratio(self):
+        return self.s.ratio()
 
 
 def add_diff_tag(diff_type, text):

--- a/htmldiffer/diff.py
+++ b/htmldiffer/diff.py
@@ -24,13 +24,14 @@ class HTMLDiffer:
         else:
             self.html_b = html_b
 
-        self.deleted_diff, self.inserted_diff, self.combined_diff, self.s = self.diff(diff_level=diff_level, 
+        self.deleted_diff, self.inserted_diff, self.combined_diff, self.s = self.diff(html_a, html_b,
+                                                                                      diff_level=diff_level, 
                                                                                       autojunk=autojunk)
         
-    def diff(self, diff_level='word', autojunk=False):
+    def diff(self, html_a, html_b, diff_level='word', autojunk=False):
         """Takes in strings a and b and returns HTML diffs: deletes, inserts, and combined."""
 
-        a, b = html2list(self.html_a, level=diff_level), html2list(self.html_b, level=diff_level)
+        a, b = html2list(html_a, level=diff_level), html2list(html_b, level=diff_level)
         if settings.ADD_STYLE:
             a, b = add_stylesheet(a), add_stylesheet(b)
 

--- a/htmldiffer/diff.py
+++ b/htmldiffer/diff.py
@@ -6,7 +6,7 @@ from .utils import *
 
 
 class HTMLDiffer:
-    def __init__(self, html_a, html_b, encoding=None, autojunk=False):
+    def __init__(self, html_a, html_b, diff_level='word', encoding=None, autojunk=False):
         if isinstance(html_a, BeautifulSoup):
             self.html_a = html_a.prettify()
         
@@ -24,12 +24,13 @@ class HTMLDiffer:
         else:
             self.html_b = html_b
 
-        self.deleted_diff, self.inserted_diff, self.combined_diff = self.diff(autojunk=autojunk)
+        self.deleted_diff, self.inserted_diff, self.combined_diff = self.diff(diff_level=diff_level, 
+                                                                              autojunk=autojunk)
 
-    def diff(self, autojunk=False):
+    def diff(self, diff_level='word', autojunk=False):
         """Takes in strings a and b and returns HTML diffs: deletes, inserts, and combined."""
 
-        a, b = html2list(self.html_a), html2list(self.html_b)
+        a, b = html2list(self.html_a, level=diff_level), html2list(self.html_b, level=diff_level)
         if settings.ADD_STYLE:
             a, b = add_stylesheet(a), add_stylesheet(b)
 

--- a/htmldiffer/diff.py
+++ b/htmldiffer/diff.py
@@ -1,95 +1,85 @@
-import os
 from bs4 import BeautifulSoup
 import difflib
 from . import settings
-from .utils import *
+from . import utils
 
 
 class HTMLDiffer:
     def __init__(self, html_a, html_b, diff_level='word', encoding=None, autojunk=False):
-        if isinstance(html_a, BeautifulSoup):
-            self.html_a = html_a.prettify()
-        
-        elif os.path.isfile(html_a):
-            with open(html_a, "r", encoding=encoding) as file_a:
-                self.html_a = file_a.read()
-        else:
-            self.html_a = html_a
-        if isinstance(html_b, BeautifulSoup):
-            self.html_b = html_b.prettify()
-        
-        elif os.path.isfile(html_b):
-            with open(html_b, "r", encoding=encoding) as file_b:
-                self.html_b = file_b.read()
-        else:
-            self.html_b = html_b
+        html_a = utils.check_html(html_a, encoding=encoding), 
+        html_b = utils.check_html(html_b, encoding=encoding)
 
-        self.deleted_diff, self.inserted_diff, self.combined_diff, self.s = self.diff(html_a, html_b,
-                                                                                      diff_level=diff_level, 
-                                                                                      autojunk=autojunk)
+        diff = self.diff(html_a, html_b,
+                         diff_level=diff_level, 
+                         autojunk=autojunk)
+        self.deleted_diff, self.inserted_diff, self.combined_diff = diff[0:3]
+        self.s = diff[3]
         
     def diff(self, html_a, html_b, diff_level='word', autojunk=False):
         """Takes in strings a and b and returns HTML diffs: deletes, inserts, and combined."""
 
-        a, b = html2list(html_a, level=diff_level), html2list(html_b, level=diff_level)
+        a, b = utils.html2list(html_a, level=diff_level), utils.html2list(html_b, level=diff_level)
         if settings.ADD_STYLE:
-            a, b = add_stylesheet(a), add_stylesheet(b)
-
-        out = [[], [], []]
-
+            a, b = utils.add_stylesheet(a), utils.add_stylesheet(b)
         try:
             # autojunk can cause malformed HTML, but also speeds up processing.
             s = difflib.SequenceMatcher(None, a, b, autojunk=autojunk)
         except TypeError:
             s = difflib.SequenceMatcher(None, a, b)
-
-        for e in s.get_opcodes():
-            old_el = a[e[1]:e[2]]
-            new_el = b[e[3]:e[4]]
-
-            if e[0] == "equal" or no_changes_exist(old_el, new_el):
-                append_text(out, deleted=''.join(old_el), inserted=''.join(new_el), both=''.join(new_el))
-
-            elif e[0] == "replace":
-                deletion = wrap_text("delete", old_el)
-                insertion = wrap_text("insert", new_el)
-                append_text(out, deleted=deletion, inserted=insertion, both=deletion + insertion)
-
-            elif e[0] == "delete":
-                deletion = wrap_text("delete", old_el)
-                append_text(out, deleted=deletion, inserted=None, both=deletion)
-
-            elif e[0] == "insert":
-                insertion = wrap_text("insert", new_el)
-                append_text(out, deleted=None, inserted=insertion, both=insertion)
-
-            else:
-                raise "Um, something's broken. I didn't expect a '" + repr(e[0]) + "'."
-
-        deleted_diff = ''.join(out[0])
-        inserted_diff = ''.join(out[1])
-
-        # using BeautifulSoup to fix any potentially broken tags
-        # see https://github.com/anastasia/htmldiffer/issues/28
-        combined_diff = str(BeautifulSoup(''.join(out[2]), 'html.parser'))
+        
+        deleted_diff, inserted_diff, combined_diff = diff_from_sequence_matcher(s, a, b)
         
         return deleted_diff, inserted_diff, combined_diff, s
     
     def ratio(self):
         return self.s.ratio()
+
+
+def diff_from_sequence_matcher(s, a, b):
+    out = [[], [], []]
+    for e in s.get_opcodes():
+        old_el = a[e[1]:e[2]]
+        new_el = b[e[3]:e[4]]
+
+        if e[0] == "equal" or no_changes_exist(old_el, new_el):
+            append_text(out, deleted=''.join(old_el), inserted=''.join(new_el), both=''.join(new_el))
+
+        elif e[0] == "replace":
+            deletion = wrap_text("delete", old_el)
+            insertion = wrap_text("insert", new_el)
+            append_text(out, deleted=deletion, inserted=insertion, both=deletion + insertion)
+
+        elif e[0] == "delete":
+            deletion = wrap_text("delete", old_el)
+            append_text(out, deleted=deletion, inserted=None, both=deletion)
+
+        elif e[0] == "insert":
+            insertion = wrap_text("insert", new_el)
+            append_text(out, deleted=None, inserted=insertion, both=insertion)
+
+        else:
+            raise "Um, something's broken. I didn't expect a '" + repr(e[0]) + "'."
+
+    deleted_diff = ''.join(out[0])
+    inserted_diff = ''.join(out[1])
+
+    # using BeautifulSoup to fix any potentially broken tags
+    # see https://github.com/anastasia/htmldiffer/issues/28
+    combined_diff = str(BeautifulSoup(''.join(out[2]), 'html.parser'))
+    return deleted_diff, inserted_diff, combined_diff
     
 
 def add_diff_tag(diff_type, text):
-    diff_class = get_class_decorator("change", diff_type)
+    diff_class = utils.get_class_decorator("change", diff_type)
     return '<span class="%s">%s</span>' % (diff_class, text)
 
 
 def add_diff_class(diff_type, original_tag):
     # if closing tag like </div> return out immediately
-    if is_closing_tag(original_tag):
+    if utils.is_closing_tag(original_tag):
         return original_tag
 
-    diff_class = get_class_decorator("tag_change", diff_type)
+    diff_class = utils.get_class_decorator("tag_change", diff_type)
 
     if len(original_tag.split("class=")) > 1:
         # determine if single or double quote
@@ -104,7 +94,7 @@ def add_diff_class(diff_type, original_tag):
         end_of_content = ''.join(contents[2:])
         new_tag = beginning_of_content + ' class="' + class_content + ' ' + diff_class + '"' + end_of_content
     else:
-        if is_self_closing_tag(original_tag):
+        if utils.is_self_closing_tag(original_tag):
             new_tag = original_tag[:-2] + ' class="%s"' % diff_class + "/>"
         else:
             new_tag = original_tag[:-1] + ' class="%s"' % diff_class + ">"
@@ -134,7 +124,7 @@ def append_text(out, deleted=None, inserted=None, both=None):
 
 
 def wrap_text(diff_type, text_list):
-    idx, just_text, outcome = [0, '', []]
+    idx, outcome = 0, []
     joined = ''.join(text_list)
 
     if joined.isspace():
@@ -143,13 +133,13 @@ def wrap_text(diff_type, text_list):
     while idx < len(text_list):
         el = text_list[idx]
 
-        if is_tag(el):
-            tag = extract_tagname(el)
-            if is_whitelisted_tag(tag):
+        if utils.is_tag(el):
+            tag = utils.extract_tagname(el)
+            if utils.is_whitelisted_tag(tag):
                 outcome.append(add_diff_tag(diff_type, el))
             else:
                 # insert diff class into tag
-                if is_blacklisted_tag(tag):
+                if utils.is_blacklisted_tag(tag):
                     outcome.append(el)
                 else:
                     outcome.append(add_diff_class(diff_type, el))

--- a/htmldiffer/diff.py
+++ b/htmldiffer/diff.py
@@ -124,7 +124,7 @@ def append_text(out, deleted=None, inserted=None, both=None):
 
 
 def wrap_text(diff_type, text_list):
-    idx, outcome = 0, []
+    idx, just_text, outcome = [0, '', []]
     joined = ''.join(text_list)
 
     if joined.isspace():

--- a/htmldiffer/diff.py
+++ b/htmldiffer/diff.py
@@ -7,12 +7,18 @@ from .utils import *
 
 class HTMLDiffer:
     def __init__(self, html_a, html_b, encoding=None, autojunk=False):
-        if os.path.isfile(html_a):
+        if isinstance(html_a, BeautifulSoup):
+            self.html_a = html_a.prettify()
+        
+        elif os.path.isfile(html_a):
             with open(html_a, "r", encoding=encoding) as file_a:
                 self.html_a = file_a.read()
         else:
             self.html_a = html_a
-        if os.path.isfile(html_b):
+        if isinstance(html_b, BeautifulSoup):
+            self.html_b = html_b.prettify()
+        
+        elif os.path.isfile(html_b):
             with open(html_b, "r", encoding=encoding) as file_b:
                 self.html_b = file_b.read()
         else:

--- a/htmldiffer/diff.py
+++ b/htmldiffer/diff.py
@@ -6,21 +6,21 @@ from .utils import *
 
 
 class HTMLDiffer:
-    def __init__(self, html_a, html_b):
+    def __init__(self, html_a, html_b, encoding=None, autojunk=False):
         if os.path.isfile(html_a):
-            with open(html_a, "r") as file_a:
+            with open(html_a, "r", encoding=encoding) as file_a:
                 self.html_a = file_a.read()
         else:
             self.html_a = html_a
         if os.path.isfile(html_b):
-            with open(html_b, "r") as file_b:
+            with open(html_b, "r", encoding=encoding) as file_b:
                 self.html_b = file_b.read()
         else:
             self.html_b = html_b
 
-        self.deleted_diff, self.inserted_diff, self.combined_diff = self.diff()
+        self.deleted_diff, self.inserted_diff, self.combined_diff = self.diff(autojunk=autojunk)
 
-    def diff(self):
+    def diff(self, autojunk=False):
         """Takes in strings a and b and returns HTML diffs: deletes, inserts, and combined."""
 
         a, b = html2list(self.html_a), html2list(self.html_b)
@@ -31,7 +31,7 @@ class HTMLDiffer:
 
         try:
             # autojunk can cause malformed HTML, but also speeds up processing.
-            s = difflib.SequenceMatcher(None, a, b, autojunk=False)
+            s = difflib.SequenceMatcher(None, a, b, autojunk=autojunk)
         except TypeError:
             s = difflib.SequenceMatcher(None, a, b)
 

--- a/htmldiffer/diff.py
+++ b/htmldiffer/diff.py
@@ -6,19 +6,18 @@ from . import utils
 
 class HTMLDiffer:
     def __init__(self, html_a, html_b, diff_level='word', encoding=None, autojunk=False):
-        html_a = utils.check_html(html_a, encoding=encoding), 
-        html_b = utils.check_html(html_b, encoding=encoding)
+        self.html_a = utils.check_html(html_a, encoding=encoding) 
+        self.html_b = utils.check_html(html_b, encoding=encoding)
 
-        diff = self.diff(html_a, html_b,
-                         diff_level=diff_level, 
+        diff = self.diff(diff_level=diff_level, 
                          autojunk=autojunk)
         self.deleted_diff, self.inserted_diff, self.combined_diff = diff[0:3]
         self.s = diff[3]
         
-    def diff(self, html_a, html_b, diff_level='word', autojunk=False):
+    def diff(self, diff_level='word', autojunk=False):
         """Takes in strings a and b and returns HTML diffs: deletes, inserts, and combined."""
 
-        a, b = utils.html2list(html_a, level=diff_level), utils.html2list(html_b, level=diff_level)
+        a, b = utils.html2list(self.html_a, level=diff_level), utils.html2list(self.html_b, level=diff_level)
         if settings.ADD_STYLE:
             a, b = utils.add_stylesheet(a), utils.add_stylesheet(b)
         try:

--- a/htmldiffer/utils.py
+++ b/htmldiffer/utils.py
@@ -3,9 +3,11 @@ import re
 from .settings import *
 
 
-def html2list(html_string):
+def html2list(html_string, level='word'):
     """
-    :param html_string: any ol' html string you've got
+    :param  html_string: any ol' html string you've got
+            level:  either 'word' or 'character'. If level='word', elements will be words.
+                    If level='character', elements will be individial characters.
     :return: list of elements, making sure not to break up open tags (even if they contain attributes)
     Note that any blacklisted tag will not be broken up
     Example:
@@ -61,7 +63,12 @@ def html2list(html_string):
             
             # otherwise, simply continue building up the current element
             else:
-                cur += c
+                if level == 'word':
+                    cur += c
+                elif level == 'character':
+                    out.append(c)
+                else:
+                    raise ValueError('level must be "word" or "character"')
 
     # TODO: move this to its own function `merge_blacklisted` or `merge_tags` return to a generator instead of list
     cleaned = list()

--- a/htmldiffer/utils.py
+++ b/htmldiffer/utils.py
@@ -1,6 +1,9 @@
 import re
+import os
 
-from .settings import *
+from bs4 import BeautifulSoup
+
+from . import settings
 
 
 def html2list(html_string, level='word'):
@@ -77,7 +80,7 @@ def html2list(html_string, level='word'):
 
     for x in out:
         if not blacklisted_tag:
-            for tag in BLACKLISTED_TAGS:
+            for tag in settings.BLACKLISTED_TAGS:
                 if verified_blacklisted_tag(x, tag):
                     blacklisted_tag = tag
                     blacklisted_string += x
@@ -96,6 +99,17 @@ def html2list(html_string, level='word'):
     return cleaned
 
 
+def check_html(html, encoding=None):
+    if isinstance(html, BeautifulSoup):
+        html = html.prettify()    
+    elif os.path.isfile(html):
+        with open(html, "r", encoding=encoding) as file:
+            html = file.read()
+    else:
+        html = html
+    return html
+
+
 def verified_blacklisted_tag(x, tag):
     """
     check for '<' + blacklisted_tag +  ' ' or '>'
@@ -107,7 +121,7 @@ def verified_blacklisted_tag(x, tag):
 
 
 def add_stylesheet(html_list):
-    stylesheet_tag = '<link rel="stylesheet" type="text/css" href="{}">'.format(STYLESHEET)
+    stylesheet_tag = '<link rel="stylesheet" type="text/css" href="{}">'.format(settings.STYLESHEET)
     for idx, el in enumerate(html_list):
         if "</head>" in el:
             # add at the very end of head tag cause we is important
@@ -186,9 +200,9 @@ def chart_tag(tag_string):
 def get_class_decorator(name, diff_type=''):
     """returns class like `htmldiffer-tag-change`"""
     if diff_type:
-        return "%s_%s" % (HTMLDIFFER_CLASS_STRINGS[name], diff_type)
+        return "%s_%s" % (settings.HTMLDIFFER_CLASS_STRINGS[name], diff_type)
     else:
-        return "%s" % (HTMLDIFFER_CLASS_STRINGS[name])
+        return "%s" % (settings.HTMLDIFFER_CLASS_STRINGS[name])
 
 
 # ===============================
@@ -198,7 +212,7 @@ def get_class_decorator(name, diff_type=''):
 # predicate functions are used -- these are not currently used for parsing.
 
 def is_blacklisted_tag(tag):
-    return tag in BLACKLISTED_TAGS
+    return tag in settings.BLACKLISTED_TAGS
 
 
 def is_comment(text):
@@ -211,7 +225,7 @@ def is_ignorable(text):
 
 def is_whitelisted_tag(tag):
     # takes a tag and checks against WHITELISTED
-    return tag in WHITELISTED_TAGS
+    return tag in settings.WHITELISTED_TAGS
 
 
 def is_open_script_tag(x):

--- a/htmldiffer/utils.py
+++ b/htmldiffer/utils.py
@@ -100,6 +100,8 @@ def html2list(html_string, level='word'):
 
 
 def check_html(html, encoding=None):
+    from copy import deepcopy
+    html = deepcopy(html)
     if isinstance(html, BeautifulSoup):
         html = html.prettify()    
     elif os.path.isfile(html):

--- a/htmldiffer/utils.py
+++ b/htmldiffer/utils.py
@@ -1,3 +1,5 @@
+import re
+
 from .settings import *
 
 
@@ -53,10 +55,16 @@ def html2list(html_string):
 
             # when we reach the next 'word', store and continue
             # FIXME: use isspace() instead of c == ' ', here
-            elif c == ' ':
-                out.append(cur+c)   # NOTE: we add spaces here so that we preserve structure
+#            elif c == ' ':
+#                out.append(cur+c)   # NOTE: we add spaces here so that we preserve structure
+#                cur = ''
+            
+            # if c is a special character, store 'word', store c, continue
+            elif is_special_character(c):
+                out.append(cur)
+                out.append(c)
                 cur = ''
-
+            
             # otherwise, simply continue building up the current element
             else:
                 cur += c
@@ -235,3 +243,9 @@ def is_text(x):
 
 def is_div(x):
     return x[0:4] == "<div" and x[-6:] == "</div>"
+
+
+def is_special_character(string):
+    char_re = re.compile(r'[^a-zA-Z0-9]')
+    string = char_re.search(string)
+    return bool(string)

--- a/htmldiffer/utils.py
+++ b/htmldiffer/utils.py
@@ -100,8 +100,6 @@ def html2list(html_string, level='word'):
 
 
 def check_html(html, encoding=None):
-    from copy import deepcopy
-    html = deepcopy(html)
     if isinstance(html, BeautifulSoup):
         html = html.prettify()    
     elif os.path.isfile(html):

--- a/htmldiffer/utils.py
+++ b/htmldiffer/utils.py
@@ -52,12 +52,6 @@ def html2list(html_string):
                     out.append(cur)   # if we have already started a new element, store it
                 cur = c               # being our tag
                 mode = TAG            # swap to tag mode
-
-            # when we reach the next 'word', store and continue
-            # FIXME: use isspace() instead of c == ' ', here
-#            elif c == ' ':
-#                out.append(cur+c)   # NOTE: we add spaces here so that we preserve structure
-#                cur = ''
             
             # if c is a special character, store 'word', store c, continue
             elif is_special_character(c):

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -28,8 +28,8 @@ class TestDiffMethods(unittest.TestCase):
 
     def test_add_stylesheet(self):
         """Test adding style string and custom style string to <head> of the html string"""
-        html_list = html2list(html_str)
-        new_html_list = add_stylesheet(html_list)
+        html_list = utils.html2list(html_str)
+        new_html_list = utils.add_stylesheet(html_list)
         self.assertNotEqual(new_html_list[1], '</head>')
         new_html_string = "".join(new_html_list)
         self.assertTrue('.css\"></head>' in new_html_string)


### PR DESCRIPTION
If not specifed, the class will default to previous defaults. Small but quite useful update. Default encoding settings for open() can cause trouble for some files. Autojunk seems to make a huge difference in run time for large files (as in hours down to minutes).